### PR TITLE
Add Sidekiq Middleware for SLI Metrics

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,6 @@
 
 AllCops:
   TargetRubyVersion: 2.6
-  TargetRailsVersion: 6.0
 
 Style/StringLiterals:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,10 @@ Style/StringLiterals:
 Style/ClassVars:
   Enabled: false
 
+Metrics/AbcSize:
+  Max: 30
+  Severity: refactor
+
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
   Max: 20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### v0.0.10 - 2021-01-19
+-  add sidekiq middleware for sli metrics
+
 ### v0.0.9 - 2020-12-11
 ### v0.0.8 - 2020-12-08
 -  remove controller_class_name use class.name

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    slimy (0.0.9)
+    slimy (0.0.10)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
     builder (3.2.4)
     bump (0.10.0)
     coderay (1.1.2)
+    connection_pool (2.2.3)
     ffi (1.9.25)
     formatador (0.2.5)
     guard (2.14.2)
@@ -56,6 +57,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    redis (4.2.5)
     rubocop (0.75.1)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
@@ -66,6 +68,10 @@ GEM
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
     shellany (0.0.1)
+    sidekiq (6.1.2)
+      connection_pool (>= 2.2.2)
+      rack (~> 2.0)
+      redis (>= 4.2.0)
     slop (3.6.0)
     thor (0.20.3)
     timecop (0.9.2)
@@ -84,6 +90,7 @@ DEPENDENCIES
   rack (~> 2.0)
   rake (~> 10.4, >= 10.4.2)
   rubocop
+  sidekiq (~> 6.1)
   slimy!
   timecop (~> 0.9)
 

--- a/lib/slimy.rb
+++ b/lib/slimy.rb
@@ -6,6 +6,7 @@ require "slimy/config"
 require "slimy/rack"
 require "slimy/rails"
 require "slimy/reporters"
+require "slimy/sidekiq"
 
 # Slimy module for SLI Instrumentation
 module Slimy

--- a/lib/slimy/sidekiq.rb
+++ b/lib/slimy/sidekiq.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Slimy
+  # sidekiq integration for slimy
+  module Sidekiq
+    autoload :SLIMiddleware, "slimy/sidekiq/middleware"
+  end
+end

--- a/lib/slimy/sidekiq/middleware.rb
+++ b/lib/slimy/sidekiq/middleware.rb
@@ -37,7 +37,7 @@ module Slimy
 
       def setup_context(worker, queue)
         ctx = Slimy::Context.new(deadline: 200, type: "sidekiq")
-        ctx.tags = @default_tags.merge(queue: queue)
+        ctx.tags = @default_tags.merge(queue: queue, job: worker.class.name)
         if worker.respond_to?(:sli_tags) && worker.sli_tags.is_a?(Hash)
           ctx.tags.merge! worker.sli_tags
         end

--- a/lib/slimy/sidekiq/middleware.rb
+++ b/lib/slimy/sidekiq/middleware.rb
@@ -4,6 +4,8 @@ module Slimy
   module Sidekiq
     # sidekiq middleware for tracking job SLIs
     class SLIMiddleware
+      DEFAULT_DEADLINE = 200
+
       def initialize(opts = {})
         @reporter =
           if opts.key? :reporter
@@ -36,7 +38,7 @@ module Slimy
       private
 
       def setup_context(worker, queue)
-        ctx = Slimy::Context.new(deadline: 200, type: "sidekiq")
+        ctx = Slimy::Context.new(deadline: DEFAULT_DEADLINE, type: "sidekiq")
         set_tags!(ctx, worker, queue)
         set_deadline!(ctx, worker, queue)
         ctx

--- a/lib/slimy/sidekiq/middleware.rb
+++ b/lib/slimy/sidekiq/middleware.rb
@@ -37,16 +37,15 @@ module Slimy
 
       def setup_context(worker, queue)
         ctx = Slimy::Context.new(deadline: 200, type: "sidekiq")
-        ctx.tags = @default_tags
+        ctx.tags = @default_tags.merge(queue: queue)
+        if worker.respond_to?(:sli_tags) && worker.sli_tags.is_a?(Hash)
+          ctx.tags.merge! worker.sli_tags
+        end
 
         if worker.respond_to?(:sli_deadline)
           ctx.deadline = worker.sli_deadline
         elsif @default_deadlines.key?(queue.to_sym)
           ctx.deadline = @default_deadlines[queue.to_sym]
-        end
-
-        if worker.respond_to?(:sli_tags) && worker.sli_tags.is_a?(Hash)
-          ctx.tags.merge! worker.sli_tags
         end
 
         ctx

--- a/lib/slimy/sidekiq/middleware.rb
+++ b/lib/slimy/sidekiq/middleware.rb
@@ -1,0 +1,52 @@
+module Slimy::Sidekiq
+
+  class SLIMiddleware
+
+    def initialize(opts = {})
+      @reporter = Slimy::Configuration.default.reporter
+      @default_tags = opts[:tags] || {}
+      @default_deadlines = opts[:deadlines] || {}
+    end
+
+    def call(worker, msg, queue)
+      context = setup_context(worker, msg, queue)
+      begin
+        result = yield
+        # todo figure out how to check if job was error?
+        # can the job fail/error without raising an exception?
+      rescue Exception => error
+        context.result_error!
+        raise error
+      ensure
+        context.finish
+        report(context)
+        return result
+      end
+    end
+
+    def report(context)
+      @reporter.report(context) unless @reporter.nil?
+    end
+
+    private
+
+    def setup_context(worker, msg, queue)
+      ctx = Slimy::Context.new(deadline: 200, type: 'sidekiq')
+      ctx.tags = @default_tags
+
+      if @default_deadlines.key?(queue.to_sym)
+        ctx.deadline = @default_deadlines[queue.to_sym]
+      end
+
+      if worker.respond_to?(:sli_deadline)
+        ctx.deadline = worker.sli_deadline
+      end
+
+      if worker.respond_to?(:sli_tags) && worker.sli_tags.is_a? Hash
+        ctx.tags.merge! worker.sli_tags
+      end
+
+      return ctx
+    end
+  end
+end

--- a/lib/slimy/version.rb
+++ b/lib/slimy/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Slimy
-  VERSION = "0.0.9"
+  VERSION = "0.0.10"
 end

--- a/slimy.gemspec
+++ b/slimy.gemspec
@@ -27,5 +27,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rack", "~> 2.0"
   s.add_development_dependency "rake", "~> 10.4", ">= 10.4.2"
   s.add_development_dependency "rubocop"
+  s.add_development_dependency "sidekiq", "~> 6.1"
   s.add_development_dependency "timecop", "~> 0.9"
 end

--- a/test/slimy/rack_middleware_test.rb
+++ b/test/slimy/rack_middleware_test.rb
@@ -57,15 +57,3 @@ class ContextTest < Minitest::Test
     refute(@reporter.ctx.success?, "SLI metric should be a failure")
   end
 end
-
-class DummyReporter
-  def initialize
-    @ctx = nil
-  end
-
-  def report(ctx)
-    @ctx = ctx
-  end
-
-  attr_reader :ctx
-end

--- a/test/slimy/sidekiq_middleware_test.rb
+++ b/test/slimy/sidekiq_middleware_test.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "sidekiq"
+require "slimy/sidekiq/middleware"
+
+class TimecopWorker
+  include Sidekiq::Worker
+  def perform(time)
+    Timecop.freeze(Time.now + time)
+  end
+end
+
+class OverrideWorker
+  include Sidekiq::Worker
+
+  attr_accessor :sli_tags
+  attr_accessor :sli_deadline
+
+  def initialize(tags = {}, deadline = 1000)
+    @sli_tags = tags
+    @sli_deadline = deadline
+  end
+
+  def perform(time)
+    Timecop.freeze(Time.now + time)
+  end
+end
+
+class ExceptionWorker
+  include Sidekiq::Worker
+  def perform
+    raise StandardError
+  end
+end
+
+class SidekiqMiddlewareTest < Minitest::Test
+  def setup
+    @reporter = DummyReporter.new
+  end
+
+  def teardown
+    Timecop.return
+  end
+
+  def middleware(opts = {})
+    opts.merge!(reporter: @reporter)
+    Slimy::Sidekiq::SLIMiddleware.new(opts)
+  end
+
+  def test_job_sli_success
+    middleware.call(TimecopWorker.new, {}, "default") do
+      TimecopWorker.new.perform(0.1)
+    end
+    assert(@reporter.ctx.success?, "SLI metric should be successful")
+  end
+
+  def test_job_default_deadline_slow
+    middleware.call(TimecopWorker.new, {}, "default") do
+      TimecopWorker.new.perform(0.3)
+    end
+    refute(@reporter.ctx.success?, "SLI metric should be a failure")
+  end
+
+  def test_job_exception_sli_failure
+    assert_raises StandardError do
+      middleware.call(TimecopWorker.new, {}, "default") do
+        ExceptionWorker.new.perform
+      end
+    end
+    refute(@reporter.ctx.success?, "SLI metric should be a failure")
+  end
+
+  def test_job_override_deadline_success
+    worker = OverrideWorker.new
+    worker.sli_deadline = 600
+    middleware.call(worker, {}, "default") do
+      worker.perform(0.5)
+    end
+    assert(@reporter.ctx.success?, "SLI metric should be successful")
+  end
+
+  def test_job_override_deadline_failuire
+    worker = OverrideWorker.new
+    worker.sli_deadline = 800
+    middleware.call(worker, {}, "default") do
+      worker.perform(0.9)
+    end
+    refute(@reporter.ctx.success?, "SLI metric should be a failure")
+  end
+
+  def test_job_override_tags
+    worker = OverrideWorker.new
+    worker.sli_tags = { team: "team1" }
+    middleware.call(worker, {}, "default") do
+      worker.perform(0.9)
+    end
+
+    assert(
+      @reporter.ctx.tags[:team] == "team1",
+      "SLI context should allow tag override"
+    )
+  end
+
+  def test_default_queue_deadline_success
+    mw = middleware(deadlines: { custom_queue: 2000 })
+    mw.call(TimecopWorker.new, {}, "custom_queue") do
+      TimecopWorker.new.perform(1.9)
+    end
+    assert(@reporter.ctx.success?, "SLI metric should be successful")
+  end
+
+  def test_default_queue_deadline_failure
+    mw = middleware(deadlines: { custom_queue: 2000 })
+    mw.call(TimecopWorker.new, {}, "custom_queue") do
+      TimecopWorker.new.perform(2.1)
+    end
+    refute(@reporter.ctx.success?, "SLI metric should be a failure")
+  end
+end

--- a/test/slimy/sidekiq_middleware_test.rb
+++ b/test/slimy/sidekiq_middleware_test.rb
@@ -102,6 +102,18 @@ class SidekiqMiddlewareTest < Minitest::Test
     )
   end
 
+  def test_job_override_tags_job_name
+    worker = OverrideWorker.new
+    middleware.call(worker, {}, "default") do
+      worker.perform(0.9)
+    end
+
+    assert(
+      @reporter.ctx.tags[:job] == worker.class.name,
+      "SLI context tags should include job name"
+    )
+  end
+
   def test_default_queue_deadline_success
     mw = middleware(deadlines: { custom_queue: 2000 })
     mw.call(TimecopWorker.new, {}, "custom_queue") do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,3 +9,15 @@ def freeze_ms(duration_ms)
     yield
   end
 end
+
+class DummyReporter
+  def initialize
+    @ctx = nil
+  end
+
+  def report(ctx)
+    @ctx = ctx
+  end
+
+  attr_reader :ctx
+end


### PR DESCRIPTION
# Description

- Adds a sidekiq middleware to include SLI metrics
- bumps version to v0.0.10

# Features
- Adds Queue and Worker class name as tags to all jobs
- Allows config to add default tags that apply to all jobs
- Allow tags to be added/overridden at the worker definition
- Sets default deadline of 200ms
- Allows deadline to be overridden at the worker definition
- Allows a default deadline to be set for a queue
