### PR TITLE
MIDDLEWARE_CONTEXT_KEY is mispelled

### DIFF
--- a/lib/slimy/rack/middleware.rb
+++ b/lib/slimy/rack/middleware.rb
@@ -4,7 +4,7 @@ module Slimy
   module Rack
     # rack middleware for tracking http request SLIs
     class SLIMiddleware
-      MIDDLEWARE_CONTEXT_KEY = "slimy.milddeware.context"
+      MIDDLEWARE_CONTEXT_KEY = "slimy.middleware.context"
 
       def initialize(app, options = {})
         @app = app


### PR DESCRIPTION
Remediates Issue: https://github.com/lessonly/slimy/issues/3
