### PR TITLE
Remove unnecessary debugging output, which isn't correctly pointing to ::Rails.logger anyway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### v0.0.11 - 2022-11-10
+-  Fixed Slimy::Reporters::RailsLogReporter, it should now be used to output logs through the host application's Rails.
+ 
 ### v0.0.10 - 2021-01-19
 -  add sidekiq middleware for sli metrics
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    slimy (0.0.10)
+    slimy (0.0.11)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/slimy/reporters/datadog.rb
+++ b/lib/slimy/reporters/datadog.rb
@@ -17,9 +17,7 @@ module Slimy
 
         sli_status = (context.success? ? "success" : "failure")
         current_span = Datadog.tracer.active_span
-        if current_span.nil?
-          Rails.logger.debug("COULD NOT FIND SPAN")
-        else
+        unless current_span.nil?
           set_tags_on_span(context, sli_status, current_span)
           @dogstatsd.increment("sli.#{context.type}.#{sli_status}",
                                tags: context.tags)

--- a/lib/slimy/reporters/rails_log_reporter.rb
+++ b/lib/slimy/reporters/rails_log_reporter.rb
@@ -14,7 +14,7 @@ module Slimy
       end
 
       def log(msg)
-        Rails.logger.send(@level, msg)
+        ::Rails.logger.send(@level, msg)
       end
     end
   end

--- a/lib/slimy/version.rb
+++ b/lib/slimy/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Slimy
-  VERSION = "0.0.10"
+  VERSION = "0.0.11"
 end


### PR DESCRIPTION
## Why?

Resolves [[LRE-1062]](https://seismic.atlassian.net/browse/LRE-1062)

`NoMethodError: undefined method `logger' for Slimy::Rails:Module`

## What?

During app startup and bootstrapping, Slimy is initialized.  Later, if it's unable to get a `active_span` from Datadog, it advises the developer.  The logging code is written as `Rails.logger.warn ...` which isn't actually pointing to the `Rails` from Ruby on Rails, rather a different `Rails` modules that's local to the Slimy module.

Fixes:
1. Remove unnecessary debugging output, which isn't correctly pointing to ::Rails.logger anyway
2. Update `Slimy::Reporters::RailsLogReporter` in Slimy which appears as though it's specific purpose is to make the application Rails logger accessible - yet isn't used anywhere and suffers from the same underlying problem, referring to the wrong `Rails` module.

With #2 fixed, and #1 removed because it was useless outside a local dev environment, developers of this package can now log to Rails by way of `Slimy::Reporters::RailsLogReporter`.

## Testing Notes

Ensure app starts up and responds to requests, without any new issues occur.

**Browser Compatibility**

N/A

### Reset/Before you go tasks:

None

## Review App Tasks

None

## Caveats

None

## Alternatives Considered

None

## Further Reading

None

## Merge Instructions

Please **DO NOT** squash my commits when merging


[LRE-1062]: https://seismic.atlassian.net/browse/LRE-1062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ