### PR TITLE
Fix lost rails controller tags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM ruby:2.6.5
+
+RUN apt-get update -qq && apt-get install -y nano zsh && \
+    sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" && \
+    echo "source ~/.bashrc" >> ~/.zshrc && \
+    # Fix slow zsh terminal with docker sync git volume https://github.com/ohmyzsh/ohmyzsh/issues/5066
+    git config --global --add oh-my-zsh.hide-dirty 1
+
+RUN mkdir /slimy /slimy/lib /slimy/lib/slimy
+WORKDIR /slimy
+RUN gem install bundler -v "2.3.8"
+COPY Gemfile /slimy/Gemfile
+COPY Gemfile.lock /slimy/Gemfile.lock
+COPY slimy.gemspec /slimy/slimy.gemspec
+COPY lib/slimy/version.rb /slimy/lib/slimy/version.rb
+RUN bundle install
+COPY . /slimy

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,11 +6,18 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (6.1.7.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
     ansi (1.5.0)
     ast (2.4.1)
     builder (3.2.4)
     bump (0.10.0)
     coderay (1.1.2)
+    concurrent-ruby (1.2.0)
     connection_pool (2.2.3)
     ffi (1.9.25)
     formatador (0.2.5)
@@ -27,6 +34,8 @@ GEM
     guard-minitest (2.4.6)
       guard-compat (~> 1.2)
       minitest (>= 3.0)
+    i18n (1.12.0)
+      concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.3)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -73,14 +82,19 @@ GEM
       rack (~> 2.0)
       redis (>= 4.2.0)
     slop (3.6.0)
+    spy (1.0.3)
     thor (0.20.3)
     timecop (0.9.2)
+    tzinfo (2.0.5)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (1.6.0)
+    zeitwerk (2.6.6)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport (~> 6.1)
   bump
   bundler (>= 1.0, < 3)
   guard
@@ -92,7 +106,8 @@ DEPENDENCIES
   rubocop
   sidekiq (~> 6.1)
   slimy!
+  spy (~> 1.0.3)
   timecop (~> 0.9)
 
 BUNDLED WITH
-   2.1.4
+   2.3.8

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3"
+
+services:
+  slimy:
+    build: .
+    container_name: slimy
+    volumes:
+      - .:/slimy
+      - ~/.zsh_history:/root/.zsh_history
+    tty: true
+    stdin_open: true

--- a/lib/slimy/rails/sli_concern.rb
+++ b/lib/slimy/rails/sli_concern.rb
@@ -11,32 +11,38 @@ module Slimy
       included do
         # class-level meta commands
         def self.sli_tag(tag, value, except: nil, only: nil)
-          before_action only: only, except: except do
+          undef_method("add_sli_tag_#{tag}") if method_defined?("add_sli_tag_#{tag}")
+          define_method("add_sli_tag_#{tag}") do
             add_sli_tag(tag, value)
           end
+
+          prepend_before_action :"add_sli_tag_#{tag}", only: only, except: except
         end
 
         def self.sli_tags(tags, except: nil, only: nil)
-          before_action only: only, except: except do
+          undef_method("add_sli_tags") if method_defined?("add_sli_tags")
+          define_method("add_sli_tags") do
             tags.each_pair do |tag, value|
               add_sli_tag(tag, value)
             end
           end
+
+          prepend_before_action :add_sli_tags, only: only, except: except
         end
 
         def self.sli_ignore(except: nil, only: nil)
-          before_action only: only, except: except do
-            add_sli_ignore
-          end
+          prepend_before_action :add_sli_ignore, only: only, except: except
         end
 
         def self.sli_deadline(deadline, except: nil, only: nil)
-          before_action only: only, except: except do
+          undef_method("sli_deadline") if method_defined?("sli_deadline")
+          define_method("sli_deadline") do
             add_sli_deadline(deadline)
           end
+          prepend_before_action :sli_deadline, only: only, except: except
         end
 
-        before_action do
+        prepend_before_action do
           add_sli_tag("controller", self.class.name)
           add_sli_tag("action", action_name)
         end

--- a/lib/slimy/rails/sli_concern.rb
+++ b/lib/slimy/rails/sli_concern.rb
@@ -11,7 +11,6 @@ module Slimy
       included do
         # class-level meta commands
         def self.sli_tag(tag, value, except: nil, only: nil)
-          undef_method("add_sli_tag_#{tag}") if method_defined?("add_sli_tag_#{tag}")
           define_method("add_sli_tag_#{tag}") do
             add_sli_tag(tag, value)
           end
@@ -20,7 +19,6 @@ module Slimy
         end
 
         def self.sli_tags(tags, except: nil, only: nil)
-          undef_method("add_sli_tags") if method_defined?("add_sli_tags")
           define_method("add_sli_tags") do
             tags.each_pair do |tag, value|
               add_sli_tag(tag, value)
@@ -35,7 +33,6 @@ module Slimy
         end
 
         def self.sli_deadline(deadline, except: nil, only: nil)
-          undef_method("sli_deadline") if method_defined?("sli_deadline")
           define_method("sli_deadline") do
             add_sli_deadline(deadline)
           end

--- a/slimy.gemspec
+++ b/slimy.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
 
   s.require_paths = ["lib"]
 
+  s.add_development_dependency "activesupport", "~> 6.1"
   s.add_development_dependency "bump"
   s.add_development_dependency "bundler", ">= 1.0", "< 3"
   s.add_development_dependency "guard"
@@ -28,5 +29,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake", "~> 10.4", ">= 10.4.2"
   s.add_development_dependency "rubocop"
   s.add_development_dependency "sidekiq", "~> 6.1"
+  s.add_development_dependency "spy", "~> 1.0.3"
   s.add_development_dependency "timecop", "~> 0.9"
 end

--- a/test/slimy/rails_sli_concern_test.rb
+++ b/test/slimy/rails_sli_concern_test.rb
@@ -4,18 +4,13 @@ require "rack/mock"
 require "active_support/concern"
 require "test_helper"
 
+# Tests Classes
 class NonTaggedController < MockController
   include Slimy::Rails::SLITools
 end
 
 class BaseController < MockController
   include Slimy::Rails::SLITools
-end
-
-class AuthController < BaseController
-end
-
-class UserController < BaseController
 end
 
 class RailsSLIConcernTest < Minitest::Test
@@ -25,6 +20,11 @@ class RailsSLIConcernTest < Minitest::Test
 
   def request
     MockRequest.new(context)
+  end
+
+  # Create dynamic runtime class constants to reduce boilerplate
+  def create_klass(name_const, parent_klass)
+    Object.const_set(name_const, create_class(parent_klass))
   end
 
   def test_new_non_tagged_controller_works
@@ -53,10 +53,13 @@ class RailsSLIConcernTest < Minitest::Test
   end
 
   def test_class_sli_tag_works
+    create_klass("RootController", BaseController)
+    create_klass("AuthController", RootController)
+    create_klass("UserController", RootController)
     AuthController.sli_tag(:functional_area, "authentication")
     UserController.sli_tag(:functional_area, "users")
     # Testing no threading or cross class issues
-    BaseController.sli_tag(:functional_area, "unset")
+    RootController.sli_tag(:functional_area, "unset")
 
     auth_con = AuthController.new(request)
     auth_con.add_sli_tag_functional_area
@@ -70,31 +73,35 @@ class RailsSLIConcernTest < Minitest::Test
   end
 
   def test_class_sli_tags_works
-    AuthController.sli_tags({ :functional_area => "authentication", :team => "auth" })
-    BaseController.sli_tag(:functional_area, "unset")
+    create_klass("ApplicationController", BaseController)
+    create_klass("AuthorizationController", ApplicationController)
+    AuthorizationController.sli_tags({ :functional_area => "authorization", :team => "auth" })
+    ApplicationController.sli_tag(:functional_area, "unset")
 
-    auth_con = AuthController.new(request)
+    auth_con = AuthorizationController.new(request)
     auth_con.add_sli_tags
     # Idempotent
     auth_con.add_sli_tags
 
-    assert_equal(auth_con.context.tags[:functional_area], "authentication")
+    assert_equal(auth_con.context.tags[:functional_area], "authorization")
     assert_equal(auth_con.context.tags[:team], "auth")
   end
 
   def test_prepend
-    auth_spy = Spy.on(AuthController, :prepend_before_action)
-    base_spy = Spy.on(BaseController, :prepend_before_action)
+    create_klass("AppController", BaseController)
+    create_klass("GroupController", AppController)
+    group_spy = Spy.on(GroupController, :prepend_before_action)
+    app_spy = Spy.on(AppController, :prepend_before_action)
 
-    AuthController.sli_tags({ :functional_area => "authentication", :team => "auth" })
-    BaseController.sli_tag(:functional_area, "unset")
-    AuthController.sli_deadline(600)
-    BaseController.sli_ignore
+    GroupController.sli_tags({ :functional_area => "groups", :team => "people" })
+    AppController.sli_tag(:functional_area, "unset")
+    GroupController.sli_deadline(600)
+    AppController.sli_ignore
 
-    assert_equal(auth_spy.calls.count, 2)
-    assert_equal(base_spy.calls.count, 2)
-    assert(auth_spy.has_been_called_with?(:add_sli_tags, only: nil, except: nil))
-    assert(base_spy.has_been_called_with?(:add_sli_ignore, only: nil, except: nil))
-    assert(auth_spy.has_been_called_with?(:sli_deadline, only: nil, except: nil))
+    assert_equal(group_spy.calls.count, 2)
+    assert_equal(app_spy.calls.count, 2)
+    assert(group_spy.has_been_called_with?(:add_sli_tags, only: nil, except: nil))
+    assert(app_spy.has_been_called_with?(:add_sli_ignore, only: nil, except: nil))
+    assert(group_spy.has_been_called_with?(:sli_deadline, only: nil, except: nil))
   end
 end

--- a/test/slimy/rails_sli_concern_test.rb
+++ b/test/slimy/rails_sli_concern_test.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "rack/mock"
+require "active_support/concern"
+require "test_helper"
+
+class NonTaggedController < MockController
+  include Slimy::Rails::SLITools
+end
+
+class BaseController < MockController
+  include Slimy::Rails::SLITools
+end
+
+class AuthController < BaseController
+end
+
+class UserController < BaseController
+end
+
+class RailsSLIConcernTest < Minitest::Test
+  def context
+    Slimy::Context.new(deadline: 400)
+  end
+
+  def request
+    MockRequest.new(context)
+  end
+
+  def test_new_non_tagged_controller_works
+    con = NonTaggedController.new(request)
+    assert_nil(con.context.tags[:functional_area])
+    assert_equal(con.context.deadline, 400)
+    assert(con.context.reportable?)
+  end
+
+  def test_add_sli_tag_works
+    con = NonTaggedController.new(request)
+    con.add_sli_tag(:functional_area, "sessions")
+    assert_equal(con.context.tags[:functional_area], "sessions")
+  end
+
+  def test_add_sli_ignore_works
+    con = NonTaggedController.new(request)
+    con.add_sli_ignore
+    refute(con.context.reportable?)
+  end
+
+  def test_add_sli_deadline_works
+    con = NonTaggedController.new(request)
+    con.add_sli_deadline(350)
+    assert_equal(con.context.deadline, 350)
+  end
+
+  def test_class_sli_tag_works
+    AuthController.sli_tag(:functional_area, "authentication")
+    UserController.sli_tag(:functional_area, "users")
+    # Testing no threading or cross class issues
+    BaseController.sli_tag(:functional_area, "unset")
+
+    auth_con = AuthController.new(request)
+    auth_con.add_sli_tag_functional_area
+    user_con = UserController.new(request)
+    # Test No Crossover Between Classes
+    user_con.add_sli_tag_functional_area
+    auth_con.add_sli_tag_functional_area
+
+    assert_equal(auth_con.context.tags[:functional_area], "authentication")
+    assert_equal(user_con.context.tags[:functional_area], "users")
+  end
+
+  def test_class_sli_tags_works
+    AuthController.sli_tags({ :functional_area => "authentication", :team => "auth" })
+    BaseController.sli_tag(:functional_area, "unset")
+
+    auth_con = AuthController.new(request)
+    auth_con.add_sli_tags
+    # Idempotent
+    auth_con.add_sli_tags
+
+    assert_equal(auth_con.context.tags[:functional_area], "authentication")
+    assert_equal(auth_con.context.tags[:team], "auth")
+  end
+
+  def test_prepend
+    auth_spy = Spy.on(AuthController, :prepend_before_action)
+    base_spy = Spy.on(BaseController, :prepend_before_action)
+
+    AuthController.sli_tags({ :functional_area => "authentication", :team => "auth" })
+    BaseController.sli_tag(:functional_area, "unset")
+    AuthController.sli_deadline(600)
+    BaseController.sli_ignore
+
+    assert_equal(auth_spy.calls.count, 2)
+    assert_equal(base_spy.calls.count, 2)
+    assert(auth_spy.has_been_called_with?(:add_sli_tags, only: nil, except: nil))
+    assert(base_spy.has_been_called_with?(:add_sli_ignore, only: nil, except: nil))
+    assert(auth_spy.has_been_called_with?(:sli_deadline, only: nil, except: nil))
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "minitest/autorun"
+require 'spy/integration'
 require "slimy"
 require "timecop"
 
@@ -20,4 +21,32 @@ class DummyReporter
   end
 
   attr_reader :ctx
+end
+
+class MockController
+  def self.prepend_before_action(*)
+  end
+
+  attr_accessor :request
+
+  def initialize(request)
+    @request = request
+  end
+
+  def action_name
+    "stubbed"
+  end
+
+  def context
+    @request.env[Slimy::Rack::SLIMiddleware::MIDDLEWARE_CONTEXT_KEY]
+  end
+end
+
+class MockRequest
+  attr_accessor :env
+
+  def initialize(context)
+    @env = {}
+    @env[Slimy::Rack::SLIMiddleware::MIDDLEWARE_CONTEXT_KEY] = context
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,11 @@ def freeze_ms(duration_ms)
   end
 end
 
+def create_class(parent_klass)
+  Class.new(parent_klass) do
+  end
+end
+
 class DummyReporter
   def initialize
     @ctx = nil


### PR DESCRIPTION
## Why?

Resolves [LRE-2556](https://seismic.atlassian.net/browse/LRE-2556)

We discovered through out export of the all SLI metrics that a good handful of controllers are submitting untagged functional_area requests, even though in code, it appears they are fully tagged.

We discovered that our `before_action`s in our controllers were causing halts (because of valid page redirects for things like authenication), that were preventing later before_actions from tagging the request with important data needed for our SLO dashboards. 

**Example**
_A lot of our controllers were being left as our default tag `unset` as the later before_action needed to set the tag wasn't executing before of a previous before_action redirect._

![Screenshot 2023-01-26 at 7 00 34 PM](https://user-images.githubusercontent.com/5419727/214977243-6d116d26-ba19-4f79-bc3c-9e28a7c9b607.png)

## What?

- Adjusted our SLI Concern class methods to define methods and use symbols instead of adhoc blocks
  * This allows to prepend actions to happen before any other application logic, while still maintaining execution order. 
- Add support for docker 
- Add testing for Slimy::Rails::SLITools 


## Merge Instructions

Please **DO** squash my commits when merging


[LRE-2556]: https://seismic.atlassian.net/browse/LRE-2556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ